### PR TITLE
remove usage of rakyll lib in favor of the embed feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/pkg/react/statik/statik.go
 /promlens
 /npm_licenses.tar.bz2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ARG REACT_APP_PROMLENS_ENV=hosted
 COPY . /app
 
 RUN go mod download \
-  && go install github.com/rakyll/statik \
   && apk add curl nodejs npm make tar \
   && (cd app && CYPRESS_INSTALL_BINARY=0 npm i && PUBLIC_URL=. REACT_APP_PROMLENS_ENV=${REACT_APP_PROMLENS_ENV} npm run build) \
   && make npm_licenses \

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ include Makefile.common
 
 DOCKER_IMAGE_NAME ?= promlens
 
-.PHONY: generate
-generate:
-	go generate ./pkg/react
+.PHONY: assets-compress
+assets-compress:
+	@echo '>> compressing assets'
+	scripts/compress_assets.sh
 
 .PHONY: build-ui
 build-ui:
 	cd $(REACT_APP_PATH) && npm i --legacy-peer-deps
 	cd $(REACT_APP_PATH) && PUBLIC_URL=. npm run build
-
 
 .PHONY: npm_licenses
 npm_licenses: $(REACT_APP_NODE_MODULES_PATH)
@@ -47,8 +47,8 @@ docker-build-onprem:
 
 .PHONY: clean
 clean:
-	rm ./pkg/react/statik/statik.go
-	rm -rf ./app/node_modules
+	rm -rf ./app/build
+	rm ./app/embed.go
 
 .PHONY: build
-build: build-ui generate npm_licenses common-build
+build: build-ui assets-compress npm_licenses common-build

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+
+embed.go

--- a/app/embed.go.tmpl
+++ b/app/embed.go.tmpl
@@ -1,0 +1,16 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import "embed"

--- a/app/ui.go
+++ b/app/ui.go
@@ -1,0 +1,9 @@
+package ui
+
+import (
+	"net/http"
+
+	"github.com/prometheus/common/assets"
+)
+
+var Assets = http.FS(assets.New(embedFS))

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ require (
 	cloud.google.com/go/storage v1.27.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
+	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/prometheus v0.39.1
-	github.com/rakyll/statik v0.1.7
 	github.com/russross/blackfriday/v2 v2.1.0
 	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
@@ -39,7 +40,6 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.5.1 // indirect
-	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
+github.com/prometheus/common/assets v0.2.0 h1:0P5OrzoHrYBOSM1OigWL3mY8ZvV2N4zIE/5AahrSrfM=
+github.com/prometheus/common/assets v0.2.0/go.mod h1:D17UVUE12bHbim7HzwUvtqm6gwBEaDQ0F+hIGbFbccI=
 github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdDeppTwGX4=
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -374,8 +376,6 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/prometheus v0.39.1 h1:abZM6A+sKAv2eKTbRIaHq4amM/nT07MuxRm0+QTaTj0=
 github.com/prometheus/prometheus v0.39.1/go.mod h1:GjQjgLhHMc0oo4Ko7qt/yBSJMY4hUoiAZwsYQgjaePA=
-github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
-github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/scripts/compress_assets.sh
+++ b/scripts/compress_assets.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# compress static assets
+
+set -euo pipefail
+
+cd app
+cp embed.go.tmpl embed.go
+
+GZIP_OPTS="-fk"
+# gzip option '-k' may not always exist in the latest gzip available on different distros.
+if ! gzip -k -h &>/dev/null; then GZIP_OPTS="-f"; fi
+
+dist="build"
+
+if ! [[ -d "${dist}" ]]; then
+  mkdir -p ${dist}
+  echo "<!doctype html>
+        <html lang=\"en\">
+        <head>
+          <meta charset=\"utf-8\">
+          <title>Node</title>
+          <base href=\"/\">
+          <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+          <link rel=\"icon\" type=\"image/x-icon\" href=\"favicon.ico\">
+        </head>
+        <body>
+        <div>
+          <p> This is the default index, looks like you forget to generate the react app before generating the golang endpoint.</p>
+        </div>
+        </body>
+        </html>" > ${dist}/index.html
+fi
+
+find ${dist} -type f -name '*.gz' -delete
+find ${dist} -type f -exec gzip $GZIP_OPTS '{}' \; -print0 | xargs -0 -I % echo %.gz | xargs echo //go:embed >> embed.go
+echo var embedFS embed.FS >> embed.go


### PR DESCRIPTION
Like that the build step for PromLens should be simpler. No need anymore to install the rakyll libs as a pre-step

As a side effect, the binary is tinier from 1 MB 🤣 

Signed-off-by: Augustin Husson <augustin.husson@amadeus.com>