### PR TITLE
reorganize UI dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24,17 +24,6 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
         "@fortawesome/free-solid-svg-icons": "^5.15.2",
         "@reach/router": "^1.3.4",
-        "@types/flot": "0.0.31",
-        "@types/jest": "^26.0.23",
-        "@types/jquery": "^3.5.5",
-        "@types/moment-timezone": "^0.5.30",
-        "@types/node": "^14.17.1",
-        "@types/reach__router": "^1.3.7",
-        "@types/react": "^17.0.8",
-        "@types/react-autosuggest": "^10.1.4",
-        "@types/react-dom": "^17.0.5",
-        "@types/react-redux": "^7.1.16",
-        "@types/react-resize-detector": "^5.0.0",
         "bootstrap": "^4.5.3",
         "codemirror-promql": "^0.19.0",
         "flot": "^4.2.1",
@@ -56,14 +45,24 @@
         "react-scripts": "^4.0.3",
         "redux": "^4.1.0",
         "tempusdominus-bootstrap-4": "^5.39.0",
-        "tempusdominus-core": "^5.19.0",
-        "typescript": "^4.2.4"
+        "tempusdominus-core": "^5.19.0"
       },
       "devDependencies": {
         "@bahmutov/add-typescript-to-cypress": "^2.1.2",
         "@testing-library/react-hooks": "^5.1.3",
         "@types/enzyme": "^3.10.8",
         "@types/enzyme-adapter-react-16": "^1.0.6",
+        "@types/flot": "0.0.31",
+        "@types/jest": "^26.0.23",
+        "@types/jquery": "^3.5.5",
+        "@types/moment-timezone": "^0.5.30",
+        "@types/node": "^14.17.1",
+        "@types/reach__router": "^1.3.7",
+        "@types/react": "^17.0.8",
+        "@types/react-autosuggest": "^10.1.4",
+        "@types/react-dom": "^17.0.5",
+        "@types/react-redux": "^7.1.16",
+        "@types/react-resize-detector": "^5.0.0",
         "@typescript-eslint/eslint-plugin": "^4.25.0",
         "@typescript-eslint/parser": "^4.25.0",
         "enzyme": "^3.11.0",
@@ -77,7 +76,8 @@
         "eslint-plugin-react-hooks": "^4.2.0",
         "prettier": "^2.3.0",
         "react-test-renderer": "^17.0.2",
-        "redux-devtools": "^3.7.0"
+        "redux-devtools": "^3.7.0",
+        "typescript": "^4.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3000,6 +3000,7 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/flot/-/flot-0.0.31.tgz",
       "integrity": "sha512-X+RcMQCqPlQo8zPT6cUFTd/PoYBShMQlHUeOXf05jWlfYnvLuRmluB9z+2EsOKFgUzqzZve5brx+gnFxBaHEUw==",
+      "dev": true,
       "dependencies": {
         "@types/jquery": "*"
       }
@@ -3065,6 +3066,7 @@
       "version": "26.0.23",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
       "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -3074,6 +3076,7 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
       "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "dev": true,
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -3098,6 +3101,7 @@
       "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
       "integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
       "deprecated": "This is a stub types definition. moment-timezone provides its own type definitions, so you do not need this installed.",
+      "dev": true,
       "dependencies": {
         "moment-timezone": "*"
       }
@@ -3136,6 +3140,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.7.tgz",
       "integrity": "sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3154,6 +3159,7 @@
       "version": "10.1.4",
       "resolved": "https://registry.npmjs.org/@types/react-autosuggest/-/react-autosuggest-10.1.4.tgz",
       "integrity": "sha512-NdSUpRX6u1VsLpF63ss3yBGGcTFDJZg35D9XPTOgXPaUXZTJcfglcjyYgQwiMYRsbnz438dWt2gff/qIb7sWcw==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3162,6 +3168,7 @@
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
       "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3181,6 +3188,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
       "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3223,7 +3231,8 @@
     "node_modules/@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -19793,6 +19802,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
       "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24389,6 +24399,7 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/flot/-/flot-0.0.31.tgz",
       "integrity": "sha512-X+RcMQCqPlQo8zPT6cUFTd/PoYBShMQlHUeOXf05jWlfYnvLuRmluB9z+2EsOKFgUzqzZve5brx+gnFxBaHEUw==",
+      "dev": true,
       "requires": {
         "@types/jquery": "*"
       }
@@ -24454,6 +24465,7 @@
       "version": "26.0.23",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
       "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -24463,6 +24475,7 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
       "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "dev": true,
       "requires": {
         "@types/sizzle": "*"
       }
@@ -24486,6 +24499,7 @@
       "version": "0.5.30",
       "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
       "integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
+      "dev": true,
       "requires": {
         "moment-timezone": "*"
       }
@@ -24524,6 +24538,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.7.tgz",
       "integrity": "sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -24542,6 +24557,7 @@
       "version": "10.1.4",
       "resolved": "https://registry.npmjs.org/@types/react-autosuggest/-/react-autosuggest-10.1.4.tgz",
       "integrity": "sha512-NdSUpRX6u1VsLpF63ss3yBGGcTFDJZg35D9XPTOgXPaUXZTJcfglcjyYgQwiMYRsbnz438dWt2gff/qIb7sWcw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -24550,6 +24566,7 @@
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
       "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -24569,6 +24586,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
       "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -24611,7 +24629,8 @@
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -37631,7 +37650,8 @@
     "typescript": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -19,17 +19,6 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.34",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@reach/router": "^1.3.4",
-    "@types/flot": "0.0.31",
-    "@types/jest": "^26.0.23",
-    "@types/jquery": "^3.5.5",
-    "@types/moment-timezone": "^0.5.30",
-    "@types/node": "^14.17.1",
-    "@types/reach__router": "^1.3.7",
-    "@types/react": "^17.0.8",
-    "@types/react-autosuggest": "^10.1.4",
-    "@types/react-dom": "^17.0.5",
-    "@types/react-redux": "^7.1.16",
-    "@types/react-resize-detector": "^5.0.0",
     "bootstrap": "^4.5.3",
     "codemirror-promql": "^0.19.0",
     "flot": "^4.2.1",
@@ -51,8 +40,7 @@
     "react-scripts": "^4.0.3",
     "redux": "^4.1.0",
     "tempusdominus-bootstrap-4": "^5.39.0",
-    "tempusdominus-core": "^5.19.0",
-    "typescript": "^4.2.4"
+    "tempusdominus-core": "^5.19.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -89,6 +77,17 @@
     "@testing-library/react-hooks": "^5.1.3",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",
+    "@types/flot": "0.0.31",
+    "@types/jest": "^26.0.23",
+    "@types/jquery": "^3.5.5",
+    "@types/moment-timezone": "^0.5.30",
+    "@types/node": "^14.17.1",
+    "@types/reach__router": "^1.3.7",
+    "@types/react": "^17.0.8",
+    "@types/react-autosuggest": "^10.1.4",
+    "@types/react-dom": "^17.0.5",
+    "@types/react-redux": "^7.1.16",
+    "@types/react-resize-detector": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
     "enzyme": "^3.11.0",
@@ -102,6 +101,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.3.0",
     "react-test-renderer": "^17.0.2",
-    "redux-devtools": "^3.7.0"
+    "redux-devtools": "^3.7.0",
+    "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
I'm just reorganising the dependencies. Like that we are able to make the different between the dependencies actually used to run the application, and others used for the test, typing ...etc.

Signed-off-by: Augustin Husson <augustin.husson@amadeus.com>