### PR TITLE
docs: update build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ To build PromLens from source, you need:
 
 * Go [version 1.17 or greater](https://golang.org/doc/install).
 * NodeJS [version 16 or greater](https://nodejs.org/).
+  * Note: With NodeJS v17+ you may experience an `error:0308010C:digital envelope routines::unsupported` error. This can be worked around by either exporting the following environment variable `NODE_OPTIONS=--openssl-legacy-provider` (please be aware of security considerations) or downgrading to NodeJS v16 [source](https://stackoverflow.com/a/69699772).
 * npm [version 7 or greater](https://www.npmjs.com/).
+* make (https://www.gnu.org/software/make/)
+* bzip2 (https://sourceware.org/bzip2/downloads.html)
+* curl (https://curl.se/download.html)
 
 Start by cloning the repository:
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ To build PromLens from source, you need:
 
 * Go [version 1.17 or greater](https://golang.org/doc/install).
 * NodeJS [version 16 or greater](https://nodejs.org/).
-  * Note: With NodeJS v17+ you may experience an `error:0308010C:digital envelope routines::unsupported` error. This can be worked around by either exporting the following environment variable `NODE_OPTIONS=--openssl-legacy-provider` (please be aware of security considerations) or downgrading to NodeJS v16 [source](https://stackoverflow.com/a/69699772).
+  * Note: With NodeJS v17+ you may experience an `error:0308010C:digital envelope routines::unsupported` error. This can be worked around by either exporting the following environment variable `NODE_OPTIONS=--openssl-legacy-provider` (please be aware of security considerations) or downgrading to NodeJS v16 ([source](https://stackoverflow.com/a/69699772)).
 * npm [version 7 or greater](https://www.npmjs.com/).
-* make (https://www.gnu.org/software/make/)
-* bzip2 (https://sourceware.org/bzip2/downloads.html)
-* curl (https://curl.se/download.html)
+
+_Note: This is a non-exhaustive list of dependancies, as it is assumed some standard Unix tools are available on your system. Please review build error messages for more information on missing tools._
 
 Start by cloning the repository:
 


### PR DESCRIPTION
The build process (`make build`) fails unless the newly added packages are installed, each with various errors. I have linked their home pages directly as I do not know which version is required.
A note has been added to the NodeJS requirement regarding the error that newer versions of NodeJS return during the build process.

Signed-off-by: Edward Dickson <ed.dickson@hotmail.com>

@juliusv per the guidelines in [Contributing](https://github.com/prometheus/promlens/blob/main/CONTRIBUTING.md).