### PR TITLE
Fix build: Adding back the REACT_APP_NODE_MODULES_PATH variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x
 
 REACT_APP_PATH = app
+REACT_APP_NODE_MODULES_PATH = $(REACT_APP_PATH)/node_modules
 REACT_APP_NPM_LICENSES_TARBALL = "npm_licenses.tar.bz2"
 
 include Makefile.common


### PR DESCRIPTION
The REACT_APP_NODE_MODULES_PATH was removed on https://github.com/prometheus/promlens/pull/28 which is  causing the `npm_licenses` build to fail with:

```
>> bundling npm licenses
rm -f "npm_licenses.tar.bz2"
find  -iname "license*" | tar cfj "npm_licenses.tar.bz2" --transform 's/^/npm_licenses\//' --files-from=-
find: illegal option -- i
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
tar: Option --transform is not supported
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
make: *** [npm_licenses] Error 1
```