### PR TITLE
update platforms/arch supported based on what modernc.org/libc is supporting

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -25,9 +25,15 @@ tarball:
 crossbuild:
     platforms:
         - darwin
-        - dragonfly
         - freebsd
-        - illumos
-        - linux
-        - netbsd
-        - windows
+        - linux/386
+        - linux/amd64
+        - linux/arm
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
+        - netbsd/amd64
+        - netbsd/arm
+        - windows/386
+        - windows/amd64
+        - windows/arm64


### PR DESCRIPTION
Since #42, the build is failing on the main branch because some platforms/arch are not supported by modernc.org/libc. 

This PR aligned the same amount of platform/arch currently supported by this lib. If we want to fallback this PR https://gitlab.com/cznic/libc/-/tree/master/unistd need to be updated with the platform missing.
By looking at the commits, it looks like the code is generated (perhaps partially)

Note: `dragonfly` and `illumos` platform have been removed.

Signed-off-by: Augustin Husson <husson.augustin@gmail.com>