### PR TITLE
Allow to print version informations

### DIFF
--- a/cmd/promlens/main.go
+++ b/cmd/promlens/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/promlog"
 	promlogflag "github.com/prometheus/common/promlog/flag"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -142,6 +143,7 @@ func getGrafanaBackend(url string, token string, tokenFile string) (*grafana.Bac
 
 func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "The PromLens server")
+	app.Version(version.Print("promlens"))
 	app.HelpFlag.Short('h')
 
 	sharedLinksGCSBucket := app.Flag("shared-links.gcs.bucket", "Name of the GCS bucket for storing shared links. Set the GOOGLE_APPLICATION_CREDENTIALS environment variable to point to the JSON file defining your service account credentials (needs to have permission to create, delete, and view objects in the provided bucket).").Default("").String()

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 	toolkitweb "github.com/prometheus/exporter-toolkit/web"
 
 	"github.com/prometheus/promlens/pkg/grafana"
@@ -43,6 +44,7 @@ type Config struct {
 
 // Serve serves the PromLens web UI and API.
 func Serve(cfg *Config) error {
+	prometheus.MustRegister(version.NewCollector("promlens"))
 	requestsTotal := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "promlens_http_requests_total",


### PR DESCRIPTION
Add `--version` flag to print version informations.

```
./promlens --version
promlens, version 0.2.0 (branch: main, revision: 6c65228f99dfdf18d69a54f6d695c581f5d9c2e2)
  build user:       andrea@localhost
  build date:       20221111-09:16:39
  go version:       go1.17.13
  platform:         linux/amd64
```