### PR TITLE
Modify Grafana Auth Method

### DIFF
--- a/pkg/grafana/backend.go
+++ b/pkg/grafana/backend.go
@@ -91,7 +91,7 @@ func NewBackend(grafanaURL string, authToken string) (*Backend, error) {
 				req.Host = target.Host
 				req.URL.Path = singleJoiningSlash(target.Path, strings.TrimPrefix(req.URL.Path, "/api/grafana/"))
 				log.Printf("Proxying to Grafana at %s...", req.URL.Path)
-				req.Header.Add("Authorization", "Bearer "+authToken)
+				req.Header.Set("Authorization", "Bearer "+authToken)
 				if _, ok := req.Header["User-Agent"]; !ok {
 					// explicitly disable User-Agent so it's not set to default value
 					req.Header.Set("User-Agent", "")

--- a/pkg/grafana/backend.go
+++ b/pkg/grafana/backend.go
@@ -119,7 +119,7 @@ func (b *Backend) GetDatasources() (dsSettings []DatasourceSettings, err error) 
 		return nil, fmt.Errorf("error creating request: %v", err)
 	}
 
-	req.Header.Add("Authorization", "Bearer "+b.authToken)
+	req.Header.Set("Authorization", "Bearer "+b.authToken)
 
 	c := &http.Client{}
 	resp, err := c.Do(req)


### PR DESCRIPTION
Hello. I was wondering if instead of `Add`, the `Set` method can be used to ensure that any other `Authorizations` that might exist in the case of proxying, the Grafana API call can go through successfully rather than adding an additional `Authorization Bearer` when one already exists.

In something that I'm currently working on, I need this `Add` to become a `Set` to provide proper functionality so promlens can properly connect to the UI.