### PR TITLE
Set datasource ID from url query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ To create an API token suitable for looking up datasources in Grafana:
 - Give the key a descriptive name, set the "Role" to "Admin", and set its life time to the desired duration (long is recommended, as you will need to regenerate it frequently otherwise).
 - Press "Add" and note down the displayed API key.
 
+### Set Grafana datasource in URL
+
+You can pre-select a specific grafana datasource when the page loads by appending a `ds` query parameter to the PromLens URL. For example, https://promlens.com/?ds=1. This works along with the `q` query parameter and shared links. You can find the IDs of the datasources by visiting `<promLenURL>/api/page_config`.
+
 ### Direct links to queries
 
 You can link to a specific query without creating a persisted shared link by appending a `q` query parameter to the PromLens URL. For example, https://promlens.com/?q=up directly displays and executes the query `up`. For more complex shared pages, we still recommend creating a full shared page link, as this allows more control over the tree view state, as well as the selected visualization methods.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To create an API token suitable for looking up datasources in Grafana:
 
 ### Set Grafana datasource in URL
 
-You can pre-select a specific grafana datasource when the page loads by appending a `ds` query parameter to the PromLens URL. For example, https://promlens.com/?ds=1. This works along with the `q` query parameter and shared links. You can find the IDs of the datasources by visiting `<promLenURL>/api/page_config`.
+You can pre-select a specific Grafana datasource when the page loads by appending a `ds` query parameter to the PromLens URL. For example, https://promlens.com/?ds=1. This works along with the `q` query parameter and shared links. You can find the IDs of the datasources by visiting `<PromLenURL>/api/page_config`.
 
 ### Direct links to queries
 

--- a/app/src/pages/PromLens.tsx
+++ b/app/src/pages/PromLens.tsx
@@ -191,16 +191,14 @@ const PromLens: FC<PathPrefixProps> = ({ pathPrefix }) => {
           );
         }
 
-        // Override Prometheus server from URL for proxy access
+        // Override Prometheus server from URL for proxy access.
         if (queryParams.ds) {
-          store.dispatch(
-            setServerSettings({
-              access: 'proxy',
-              datasourceID: Number(queryParams.ds),
-              withCredentials: false,
-              url: '',
-            })
-          );
+          const providedDS = pageConfig.grafanaDatasources.find((ds) => ds.id === Number(queryParams.ds));
+          if (providedDS !== undefined) {
+            store.dispatch(setServerSettings(grafanaDatasourceToServerSettings(providedDS)));
+          } else {
+            setPageConfigError('No Grafana datasource found with ID provided in the url parameter');
+          }
         }
 
         // Override the expression of the first query from the URL.

--- a/app/src/pages/PromLens.tsx
+++ b/app/src/pages/PromLens.tsx
@@ -147,6 +147,7 @@ const PromLens: FC<PathPrefixProps> = ({ pathPrefix }) => {
         // - command-line default
         // - page state from shared link
         // - explicit "?s=<server-url>" override
+        // - explicit "?ds=<datasource-id>" override
 
         // If a command-line default server is present, set that first.
         if (pageConfig.defaultPrometheusURL !== '') {
@@ -178,8 +179,7 @@ const PromLens: FC<PathPrefixProps> = ({ pathPrefix }) => {
           }
         }
 
-        // Override Prometheus server from URL.
-        // TODO: Allow passing datasource ID in URL as well.
+        // Override Prometheus server from URL for direct access.
         if (queryParams.s) {
           store.dispatch(
             setServerSettings({
@@ -187,6 +187,18 @@ const PromLens: FC<PathPrefixProps> = ({ pathPrefix }) => {
               datasourceID: null,
               withCredentials: false,
               url: queryParams.s,
+            })
+          );
+        }
+
+        // Override Prometheus server from URL for proxy access
+        if (queryParams.ds) {
+          store.dispatch(
+            setServerSettings({
+              access: 'proxy',
+              datasourceID: Number(queryParams.ds),
+              withCredentials: false,
+              url: '',
             })
           );
         }
@@ -200,7 +212,7 @@ const PromLens: FC<PathPrefixProps> = ({ pathPrefix }) => {
       })
       .catch((err) => setPageConfigError(err.message))
       .finally(() => setPageConfigLoading(false));
-  }, [queryParams.l, queryParams.s, pathPrefix]);
+  }, [queryParams.l, queryParams.s, queryParams.ds, pathPrefix]);
 
   return (
     <Container fluid className="promlens-container">


### PR DESCRIPTION
Adds the ability to set Grafana datasource ID within new url query parameter `?ds=`. So the same sharedlinks and links with `?q=` can be used with the ability to load the page with a different or correct datasource.