### PR TITLE
ci: pin contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:  # yamllint disable-line rule:truthy
     branches: [main, 'release-*']
     tags: ['v*']
 
+# Docker Hub + Quay publishes use their own secrets; release artifact
+# publishing uses PROMBOT_GITHUB_TOKEN. Default GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:  # yamllint disable-line rule:truthy
     branches: [main, 'release-*']
     tags: ['v*']
 
-# Docker Hub + Quay publishes use their own secrets; release artifact
-# publishing uses PROMBOT_GITHUB_TOKEN. Default GITHUB_TOKEN only needs read.
 permissions:
   contents: read
 


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `ci.yml`. The publish/release steps use dedicated secrets (Docker Hub / Quay creds, plus `PROMBOT_GITHUB_TOKEN` for the GitHub release), so the default token only needs read access for the checkout.